### PR TITLE
Improves pattern scanning functionality and adds corner case tests

### DIFF
--- a/.idea/editor.xml
+++ b/.idea/editor.xml
@@ -201,7 +201,7 @@
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppStaticDataMemberInUnnamedStruct/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppStaticSpecifierOnAnonymousNamespaceMember/@EntryIndexedValue" value="SUGGESTION" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppStringLiteralToCharPointerConversion/@EntryIndexedValue" value="WARNING" type="string" />
-    <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppTabsAreDisallowed/@EntryIndexedValue" value="WARNING" type="string" />
+    <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppTabsAreDisallowed/@EntryIndexedValue" value="DO_NOT_SHOW" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppTemplateArgumentsCanBeDeduced/@EntryIndexedValue" value="HINT" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppTemplateParameterNeverUsed/@EntryIndexedValue" value="HINT" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppTemplateParameterShadowing/@EntryIndexedValue" value="WARNING" type="string" />
@@ -215,7 +215,7 @@
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUnmatchedPragmaEndRegionDirective/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUnmatchedPragmaRegionDirective/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUnnamedNamespaceInHeaderFile/@EntryIndexedValue" value="WARNING" type="string" />
-    <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUnnecessaryWhitespace/@EntryIndexedValue" value="WARNING" type="string" />
+    <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUnnecessaryWhitespace/@EntryIndexedValue" value="DO_NOT_SHOW" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUnsignedZeroComparison/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUnusedIncludeDirective/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUseAlgorithmWithCount/@EntryIndexedValue" value="SUGGESTION" type="string" />

--- a/include/omath/utility/pattern_scan.hpp
+++ b/include/omath/utility/pattern_scan.hpp
@@ -1,0 +1,28 @@
+//
+// Created by Vlad on 10/4/2025.
+//
+
+#pragma once
+#include <expected>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+// ReSharper disable once CppInconsistentNaming
+class unit_test_pattern_scan_read_test_Test;
+namespace omath
+{
+    enum class PatternScanError
+    {
+        INVALID_PATTERN_STRING
+    };
+    class PatternScanner
+    {
+        friend unit_test_pattern_scan_read_test_Test;
+    public:
+    private:
+        [[nodiscard]]
+        static std::expected<std::vector<std::optional<std::byte>>, PatternScanError>
+        parse_pattern(const std::string_view& pattern_string);
+    };
+} // namespace omath

--- a/include/omath/utility/pattern_scan.hpp
+++ b/include/omath/utility/pattern_scan.hpp
@@ -10,6 +10,9 @@
 
 // ReSharper disable once CppInconsistentNaming
 class unit_test_pattern_scan_read_test_Test;
+class unit_test_pattern_scan_corner_case_1_Test;
+class unit_test_pattern_scan_corner_case_2_Test;
+class unit_test_pattern_scan_corner_case_3_Test;
 namespace omath
 {
     enum class PatternScanError
@@ -19,6 +22,9 @@ namespace omath
     class PatternScanner
     {
         friend unit_test_pattern_scan_read_test_Test;
+        friend unit_test_pattern_scan_corner_case_1_Test;
+        friend unit_test_pattern_scan_corner_case_2_Test;
+        friend unit_test_pattern_scan_corner_case_3_Test;
     public:
     private:
         [[nodiscard]]

--- a/include/omath/utility/pattern_scan.hpp
+++ b/include/omath/utility/pattern_scan.hpp
@@ -7,12 +7,20 @@
 #include <optional>
 #include <string_view>
 #include <vector>
+#include <span>
 
 // ReSharper disable once CppInconsistentNaming
 class unit_test_pattern_scan_read_test_Test;
+// ReSharper disable once CppInconsistentNaming
 class unit_test_pattern_scan_corner_case_1_Test;
+// ReSharper disable once CppInconsistentNaming
 class unit_test_pattern_scan_corner_case_2_Test;
+// ReSharper disable once CppInconsistentNaming
 class unit_test_pattern_scan_corner_case_3_Test;
+// ReSharper disable once CppInconsistentNaming
+class unit_test_pattern_scan_corner_case_4_Test;
+
+
 namespace omath
 {
     enum class PatternScanError
@@ -25,7 +33,11 @@ namespace omath
         friend unit_test_pattern_scan_corner_case_1_Test;
         friend unit_test_pattern_scan_corner_case_2_Test;
         friend unit_test_pattern_scan_corner_case_3_Test;
+        friend unit_test_pattern_scan_corner_case_4_Test;
     public:
+        [[nodiscard]]
+        static std::optional<std::span<std::byte>::const_iterator>
+        scan_for_pattern(const std::string_view& pattern, const std::span<std::byte>& range);
     private:
         [[nodiscard]]
         static std::expected<std::vector<std::optional<std::byte>>, PatternScanError>

--- a/source/utility/pattern_scan.cpp
+++ b/source/utility/pattern_scan.cpp
@@ -28,6 +28,7 @@ namespace omath
                 start = end != pattern_string.end() ? std::next(end) : end;
                 continue;
             }
+
             if (byte_str == "?" || byte_str == "??")
             {
                 pattern.emplace_back(std::nullopt);

--- a/source/utility/pattern_scan.cpp
+++ b/source/utility/pattern_scan.cpp
@@ -7,6 +7,33 @@
 namespace omath
 {
 
+    std::optional<std::span<std::byte>::const_iterator>
+    PatternScanner::scan_for_pattern(const std::string_view& pattern, const std::span<std::byte>& range)
+    {
+        const auto parsed_pattern = parse_pattern(pattern);
+
+        if (!parsed_pattern)
+            return std::nullopt;
+
+        const std::ptrdiff_t scan_size =
+                static_cast<std::ptrdiff_t>(range.size()) - static_cast<std::ptrdiff_t>(pattern.size());
+
+        for (std::ptrdiff_t i = 0; i < scan_size; i++)
+        {
+            bool found = true;
+
+            for (std::ptrdiff_t j = 0; j < static_cast<std::ptrdiff_t>(pattern.size()); j++)
+            {
+                found = parsed_pattern->at(j) == std::nullopt || parsed_pattern->at(j) == *(range.data() + i + j);
+
+                if (!found)
+                    break;
+            }
+            if (found)
+                return range.begin() + i;
+        }
+        return std::nullopt;
+    }
     std::expected<std::vector<std::optional<std::byte>>, PatternScanError>
     PatternScanner::parse_pattern(const std::string_view& pattern_string)
     {
@@ -39,13 +66,12 @@ namespace omath
 
             std::uint8_t value = 0;
             // ReSharper disable once CppTooWideScopeInitStatement
-            const auto [_, error_code] = std::from_chars(byte_str.data(), byte_str.data()+byte_str.size(), value, 16);
+            const auto [_, error_code] = std::from_chars(byte_str.data(), byte_str.data() + byte_str.size(), value, 16);
 
             if (error_code != std::errc{})
                 return std::unexpected(PatternScanError::INVALID_PATTERN_STRING);
 
             pattern.emplace_back(static_cast<std::byte>(value));
-
 
             start = end != pattern_string.end() ? std::next(end) : end;
         }

--- a/source/utility/pattern_scan.cpp
+++ b/source/utility/pattern_scan.cpp
@@ -22,7 +22,7 @@ namespace omath
         {
             bool found = true;
 
-            for (std::ptrdiff_t j = 0; j < static_cast<std::ptrdiff_t>(pattern.size()); j++)
+            for (std::ptrdiff_t j = 0; j < static_cast<std::ptrdiff_t>(parsed_pattern->size()); j++)
             {
                 found = parsed_pattern->at(j) == std::nullopt || parsed_pattern->at(j) == *(range.data() + i + j);
 

--- a/source/utility/pattern_scan.cpp
+++ b/source/utility/pattern_scan.cpp
@@ -24,8 +24,10 @@ namespace omath
             const std::string_view byte_str = pattern_string.substr(sting_view_start, sting_view_end);
 
             if (byte_str.empty())
+            {
+                start = end != pattern_string.end() ? std::next(end) : end;
                 continue;
-
+            }
             if (byte_str == "?" || byte_str == "??")
             {
                 pattern.emplace_back(std::nullopt);

--- a/source/utility/pattern_scan.cpp
+++ b/source/utility/pattern_scan.cpp
@@ -1,0 +1,51 @@
+//
+// Created by Vlad on 10/4/2025.
+//
+#include "omath/utility/pattern_scan.hpp"
+#include <charconv>
+
+namespace omath
+{
+
+    std::expected<std::vector<std::optional<std::byte>>, PatternScanError>
+    PatternScanner::parse_pattern(const std::string_view& pattern_string)
+    {
+        std::vector<std::optional<std::byte>> pattern;
+
+        auto start = pattern_string.cbegin();
+
+        while (start != pattern_string.cend())
+        {
+            const auto end = std::find(start, pattern_string.cend(), ' ');
+
+            const auto sting_view_start = std::distance(pattern_string.cbegin(), start);
+            const auto sting_view_end = std::distance(start, end);
+
+            const std::string_view byte_str = pattern_string.substr(sting_view_start, sting_view_end);
+
+            if (byte_str.empty())
+                continue;
+
+            if (byte_str == "?" || byte_str == "??")
+            {
+                pattern.emplace_back(std::nullopt);
+
+                start = end != pattern_string.end() ? std::next(end) : end;
+                continue;
+            }
+
+            std::uint8_t value = 0;
+            // ReSharper disable once CppTooWideScopeInitStatement
+            const auto [_, error_code] = std::from_chars(byte_str.data(), byte_str.data()+byte_str.size(), value, 16);
+
+            if (error_code != std::errc{})
+                return std::unexpected(PatternScanError::INVALID_PATTERN_STRING);
+
+            pattern.emplace_back(static_cast<std::byte>(value));
+
+
+            start = end != pattern_string.end() ? std::next(end) : end;
+        }
+        return pattern;
+    }
+} // namespace omath

--- a/tests/general/unit_test_pattern_scan.cpp
+++ b/tests/general/unit_test_pattern_scan.cpp
@@ -45,3 +45,10 @@ TEST(unit_test_pattern_scan, corner_case_3)
     EXPECT_EQ(result->at(2), std::nullopt);
     EXPECT_EQ(result->at(3), static_cast<std::byte>(0xE9));
 }
+
+TEST(unit_test_pattern_scan, corner_case_4)
+{
+    const auto result = omath::PatternScanner::parse_pattern("X ? ?? E9 ");
+
+    EXPECT_FALSE(result.has_value());
+}

--- a/tests/general/unit_test_pattern_scan.cpp
+++ b/tests/general/unit_test_pattern_scan.cpp
@@ -1,0 +1,11 @@
+//
+// Created by Vlad on 10/4/2025.
+//
+#include "gtest/gtest.h"
+#include <omath/utility/pattern_scan.hpp>
+#include <source_location>
+
+TEST(unit_test_pattern_scan, read_test)
+{
+    std::ignore = omath::PatternScanner::parse_pattern("FF ? ?? E9");
+}

--- a/tests/general/unit_test_pattern_scan.cpp
+++ b/tests/general/unit_test_pattern_scan.cpp
@@ -5,7 +5,43 @@
 #include <omath/utility/pattern_scan.hpp>
 #include <source_location>
 
+
 TEST(unit_test_pattern_scan, read_test)
 {
-    std::ignore = omath::PatternScanner::parse_pattern("FF ? ?? E9");
+    const auto result = omath::PatternScanner::parse_pattern("FF ? ?? E9");
+
+    EXPECT_EQ(result->at(0), static_cast<std::byte>(0xFF));
+    EXPECT_EQ(result->at(1), std::nullopt);
+    EXPECT_EQ(result->at(2), std::nullopt);
+    EXPECT_EQ(result->at(3), static_cast<std::byte>(0xE9));
+}
+
+TEST(unit_test_pattern_scan, corner_case_1)
+{
+    const auto result = omath::PatternScanner::parse_pattern("     FF ? ?? E9");
+
+    EXPECT_EQ(result->at(0), static_cast<std::byte>(0xFF));
+    EXPECT_EQ(result->at(1), std::nullopt);
+    EXPECT_EQ(result->at(2), std::nullopt);
+    EXPECT_EQ(result->at(3), static_cast<std::byte>(0xE9));
+}
+
+TEST(unit_test_pattern_scan, corner_case_2)
+{
+    const auto result = omath::PatternScanner::parse_pattern("     FF ? ?? E9       ");
+
+    EXPECT_EQ(result->at(0), static_cast<std::byte>(0xFF));
+    EXPECT_EQ(result->at(1), std::nullopt);
+    EXPECT_EQ(result->at(2), std::nullopt);
+    EXPECT_EQ(result->at(3), static_cast<std::byte>(0xE9));
+}
+
+TEST(unit_test_pattern_scan, corner_case_3)
+{
+    const auto result = omath::PatternScanner::parse_pattern("     FF ?       ??      E9       ");
+
+    EXPECT_EQ(result->at(0), static_cast<std::byte>(0xFF));
+    EXPECT_EQ(result->at(1), std::nullopt);
+    EXPECT_EQ(result->at(2), std::nullopt);
+    EXPECT_EQ(result->at(3), static_cast<std::byte>(0xE9));
 }


### PR DESCRIPTION
Updates the `pattern_scan.hpp` and `pattern_scan.cpp` files to implement a more robust pattern scanning mechanism. This includes parsing patterns with optional delimiters (e.g., "?", "??") and handling potential issues with empty patterns. Adds corner case tests for the pattern scanning logic.

Fixes #789