### PR TITLE
internal_rev_object.hpp: do not use __fastcall for non-Windows platforms

### DIFF
--- a/include/omath/rev_eng/internal_rev_object.hpp
+++ b/include/omath/rev_eng/internal_rev_object.hpp
@@ -29,7 +29,7 @@ namespace omath::rev_eng
 #ifdef _MSC_VER
             using VirtualMethodType = ReturnType(__thiscall*)(void*, decltype(arg_list)...);
 #else
-            using VirtualMethodType = ReturnType(__fastcall*)(void*, decltype(arg_list)...);
+            using VirtualMethodType = ReturnType(*)(void*, decltype(arg_list)...);
 #endif
             return (*reinterpret_cast<VirtualMethodType**>(this))[id](this, arg_list...);
         }


### PR DESCRIPTION
The problem is with the __fastcall calling convention syntax on non-MSVC compilers. The __fastcall is a Microsoft-specific calling convention that's not recognized by GCC/Clang.

```
/github/home/.xmake/packages/o/omath/v3.9.0/8998370ec7d64573a093ffd40b339792/include/omath/rev_eng/internal_rev_object.hpp:32:49: error: expected ‘;’ before ‘(’ token [-Wtemplate-body]
32 | using VirtualMethodType = ReturnType(__fastcall*)(void*, decltype(arg_list)...);
| ^
/github/home/.xmake/packages/o/omath/v3.9.0/8998370ec7d64573a093ffd40b339792/include/omath/rev_eng/internal_rev_object.hpp:34:39: error: ‘VirtualMethodType’ does not name a type [-Wtemplate-body]
34 | return (reinterpret_cast<VirtualMethodType**>(this))[id](this, arg_list...);
| ^~~~~~~~~~~~~~~~~
/github/home/.xmake/packages/o/omath/v3.9.0/8998370ec7d64573a093ffd40b339792/include/omath/rev_eng/internal_rev_object.hpp:34:56: error: expected ‘>’ before ‘’ token [-Wtemplate-body]
34 | return (*reinterpret_cast<VirtualMethodType**>(this))[id](this, arg_list...);
| ^
```

https://github.com/microsoft/vcpkg/pull/47731
https://github.com/xmake-io/xmake-repo/pull/8349