### PR TITLE
Removes Windows-specific API dependencies for pattern scanning

### DIFF
--- a/include/omath/utility/pe_pattern_scan.hpp
+++ b/include/omath/utility/pe_pattern_scan.hpp
@@ -19,7 +19,7 @@ namespace omath
     {
     public:
         [[nodiscard]]
-        static std::optional<std::uintptr_t> scan_for_pattern_in_loaded_module(const std::string_view& module_name,
+        static std::optional<std::uintptr_t> scan_for_pattern_in_loaded_module(const void* module_base_address,
                                                                                const std::string_view& pattern);
 
         [[nodiscard]]


### PR DESCRIPTION
Replaces calls to Windows API functions (GetModuleHandleA) with a void pointer parameter.

Simplifies pattern scanning for loaded modules by removing Windows-specific code and replacing it with a generic approach.
