### PR TITLE
Fix pattern scan range check to use end() instead of cend()

### DIFF
--- a/source/utility/pe_pattern_scan.cpp
+++ b/source/utility/pe_pattern_scan.cpp
@@ -328,7 +328,7 @@ namespace omath
                     // ReSharper disable once CppTooWideScopeInitStatement
                     const auto result = PatternScanner::scan_for_pattern(scan_range, pattern);
 
-                    if (result != scan_range.cend())
+                    if (result != scan_range.end())
                         return reinterpret_cast<std::uintptr_t>(&*result);
 
                     return std::nullopt;


### PR DESCRIPTION
The issue: Emscripten's implementation of std::span doesn't provide the cend() method, which is causing the compilation error.
https://github.com/xmake-io/xmake-repo/pull/8402