### PR TITLE
Adds PE signature scanner example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,9 @@
 project(examples)
 
-add_executable(ExampleProjectionMatrixBuilder example_proj_mat_builder.cpp)
-target_link_libraries(ExampleProjectionMatrixBuilder PRIVATE omath::omath)
+add_executable(example_projection_matrix_builder example_proj_mat_builder.cpp)
+set_target_properties(example_projection_matrix_builder PROPERTIES CXX_STANDARD 26)
+target_link_libraries(example_projection_matrix_builder PRIVATE omath::omath)
+
+add_executable(example_signature_scan example_signature_scan.cpp)
+set_target_properties(example_signature_scan PROPERTIES CXX_STANDARD 26)
+target_link_libraries(example_signature_scan PRIVATE omath::omath)

--- a/examples/example_signature_scan.cpp
+++ b/examples/example_signature_scan.cpp
@@ -1,0 +1,39 @@
+//
+// Created by Vlad on 11/8/2025.
+//
+
+#include <iostream>
+#include <omath/utility/pe_pattern_scan.hpp>
+#include <print>
+
+int main()
+{
+    std::println("OMATH Signature Scanner");
+
+    std::print("Enter path to PE file: ");
+    std::string file_path;
+    std::getline(std::cin, file_path); // allows spaces
+
+    std::print("Enter target section: ");
+    std::string section;
+    std::getline(std::cin, section);
+
+    std::print("Enter signature: ");
+    std::string signature;
+    std::getline(std::cin, signature);
+
+    std::println("[LOG] Performing scan....");
+
+    const auto result = omath::PePatternScanner::scan_for_pattern_in_file(file_path, signature, section);
+
+    if (!result)
+    {
+        std::println("[ERROR] Scan failed or signature was not found");
+        return -1;
+    }
+
+    std::println("Found at virtual 0x{:x} , raw 0x{:x}", result->virtual_base_addr + result->target_offset,
+               result->raw_base_addr + result->target_offset);
+
+    return 0;
+}


### PR DESCRIPTION
Implements a basic example demonstrating how to scan for a given pattern within a PE file.

The example takes a file path, section, and signature as input and utilizes the `omath::PePatternScanner` to locate the signature within the specified section of the PE file.