### PR TITLE
Add FreeBSD support

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -12,7 +12,7 @@ concurrency:
 
 
 ##############################################################################
-# 1)  ARCH LINUX  –  Clang / Ninja
+# 1)  Arch Linux  –  Clang / Ninja
 ##############################################################################
 jobs:
   arch-build-and-test:
@@ -120,3 +120,41 @@ jobs:
       - name: Run unit_tests
         shell: bash
         run: ./out/Release/unit_tests
+
+  ##############################################################################
+  # 4)  FreeBSD  –  Clang / Ninja
+  ##############################################################################
+  freebsd-build-and-test:
+    name: FreeBSD (Clang)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository (with sub-modules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build and Test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          sync: sshfs
+          mem: 12288
+          copyback: false
+          prepare: pkg install -y git curl zip unzip gmake llvm gsed bash perl5 openssl 7-zip coreutils cmake ninja pkgconf patchelf
+          run: |
+            git config --global --add safe.directory `pwd`
+            # Build vcpkg in /tmp to avoid sshfs timestamp sync issues
+            # This prevents PCH timestamp mismatches during parallel builds
+            export VCPKG_ROOT=/tmp/vcpkg
+            rm -rf "$VCPKG_ROOT"
+            git clone https://github.com/microsoft/vcpkg "$VCPKG_ROOT"
+            cd "$VCPKG_ROOT"
+            # Bootstrap vcpkg - it will build from source on FreeBSD
+            # Building in /tmp avoids sshfs timestamp issues that break PCH
+            ./bootstrap-vcpkg.sh
+            cd -
+            export VCPKG_FORCE_SYSTEM_BINARIES=0
+            # VCPKG_ROOT is set to /tmp/vcpkg, which CMake will use via the preset
+            cmake --preset freebsd-release-vcpkg -DOMATH_BUILD_TESTS=ON -DOMATH_BUILD_BENCHMARK=OFF -DVCPKG_MANIFEST_FEATURES="imgui;avx2;tests" -DVCPKG_INSTALL_OPTIONS="--allow-unsupported"
+            cmake --build cmake-build/build/freebsd-release-vcpkg --target unit_tests omath
+            ./out/Release/unit_tests

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -178,6 +178,65 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
+    },
+    {
+      "name": "freebsd-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/cmake-build/build/${presetName}",
+      "installDir": "${sourceDir}/cmake-build/install/${presetName}",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_MAKE_PROGRAM": "ninja"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "FreeBSD"
+      }
+    },
+    {
+      "name": "freebsd-base-vcpkg",
+      "hidden": true,
+      "inherits": "freebsd-base",
+      "cacheVariables": {
+        "OMATH_BUILD_VIA_VCPKG": "ON",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/cmake-build/vcpkg_installed",
+        "VCPKG_MANIFEST_FEATURES": "tests;imgui;avx2"
+      }
+    },
+    {
+      "name": "freebsd-debug",
+      "displayName": "FreeBSD Debug",
+      "inherits": "freebsd-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "freebsd-debug-vcpkg",
+      "displayName": "FreeBSD Debug Vcpkg",
+      "inherits": "freebsd-base-vcpkg",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "freebsd-release",
+      "displayName": "FreeBSD Release",
+      "inherits": "freebsd-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "freebsd-release-vcpkg",
+      "displayName": "FreeBSD Release Vcpkg",
+      "inherits": "freebsd-base-vcpkg",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     }
   ]
 }

--- a/include/omath/linear_algebra/mat.hpp
+++ b/include/omath/linear_algebra/mat.hpp
@@ -17,6 +17,13 @@
 
 #undef near
 #undef far
+// Undefine FreeBSD/BSD system macros that conflict with method names
+#ifdef minor
+#undef minor
+#endif
+#ifdef major
+#undef major
+#endif
 namespace omath
 {
     struct MatSize


### PR DESCRIPTION
FreeBSD's <sys/types.h> defines a minor macro that conflicts with the minor method.