### PR TITLE
Add NDK support

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,4 +1,4 @@
-name: Omath CI (Arch Linux / Windows)
+name: Omath CI
 
 on:
   push:
@@ -16,7 +16,7 @@ concurrency:
 ##############################################################################
 jobs:
   arch-build-and-test:
-    name: Arch Linux (Clang)
+    name: Arch Linux (Clang) (x64-linux)
     runs-on: ubuntu-latest
     container: archlinux:latest
     env:
@@ -56,7 +56,7 @@ jobs:
   # 2)  Windows  –  MSVC / Ninja
   ##############################################################################
   windows-build-and-test:
-    name: Windows (MSVC)
+    name: Windows (MSVC) (x64-windows)
     runs-on: windows-latest
     env:
       OMATH_BUILD_VIA_VCPKG: ON
@@ -89,7 +89,7 @@ jobs:
   # 3)  macOS  –  AppleClang / Ninja
   ##############################################################################
   macosx-build-and-test:
-    name: macOS (AppleClang)
+    name: macOS (AppleClang) (arm64-osx)
     runs-on: macOS-latest
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
@@ -125,7 +125,7 @@ jobs:
   # 4)  FreeBSD  –  Clang / Ninja
   ##############################################################################
   freebsd-build-and-test:
-    name: FreeBSD (Clang)
+    name: FreeBSD (Clang) (x64-freebsd)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (with sub-modules)
@@ -158,3 +158,58 @@ jobs:
             cmake --preset freebsd-release-vcpkg -DOMATH_BUILD_TESTS=ON -DOMATH_BUILD_BENCHMARK=OFF -DVCPKG_MANIFEST_FEATURES="imgui;avx2;tests" -DVCPKG_INSTALL_OPTIONS="--allow-unsupported"
             cmake --build cmake-build/build/freebsd-release-vcpkg --target unit_tests omath
             ./out/Release/unit_tests
+
+  ##############################################################################
+  # 5)  Android NDK  –  Clang / Ninja / arm64-android
+  ##############################################################################
+  android-build-and-test:
+    name: Android NDK (arm64-android)
+    runs-on: ubuntu-latest
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      ANDROID_NDK_HOME: ${{ github.workspace }}/android-ndk
+    steps:
+      - name: Checkout repository (with sub-modules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Android NDK
+        shell: bash
+        run: |
+          NDK_VERSION="r28c"
+          NDK_ZIP="android-ndk-${NDK_VERSION}-linux.zip"
+          wget -q "https://dl.google.com/android/repository/${NDK_ZIP}"
+          unzip -q "${NDK_ZIP}" -d "${{ github.workspace }}"
+          mv "${{ github.workspace }}/android-ndk-${NDK_VERSION}" "$ANDROID_NDK_HOME"
+          rm "${NDK_ZIP}"
+          echo "ANDROID_NDK_HOME=${ANDROID_NDK_HOME}" >> $GITHUB_ENV
+          echo "Android NDK installed at: ${ANDROID_NDK_HOME}"
+          ls -la "${ANDROID_NDK_HOME}" | head -5
+
+      - name: Install basic tool-chain
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake
+
+      - name: Set up vcpkg
+        shell: bash
+        run: |
+          git clone https://github.com/microsoft/vcpkg "$VCPKG_ROOT"
+          cd "$VCPKG_ROOT"
+          ./bootstrap-vcpkg.sh
+
+      - name: Configure (cmake --preset)
+        shell: bash
+        run: |
+          cmake --preset android-release-vcpkg \
+            -DVCPKG_INSTALL_OPTIONS="--allow-unsupported" \
+            -DOMATH_BUILD_TESTS=ON \
+            -DOMATH_BUILD_BENCHMARK=OFF \
+            -DVCPKG_MANIFEST_FEATURES="imgui;tests"
+
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build cmake-build/build/android-release-vcpkg --target unit_tests omath

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -237,6 +237,64 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
+    },
+    {
+      "name": "android-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/cmake-build/build/${presetName}",
+      "installDir": "${sourceDir}/cmake-build/install/${presetName}",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Android",
+        "CMAKE_SYSTEM_VERSION": "24",
+        "CMAKE_ANDROID_ARCH_ABI": "arm64-v8a",
+        "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}",
+        "CMAKE_MAKE_PROGRAM": "ninja"
+      }
+    },
+    {
+      "name": "android-base-vcpkg",
+      "hidden": true,
+      "inherits": "android-base",
+      "cacheVariables": {
+        "OMATH_BUILD_VIA_VCPKG": "ON",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/cmake-build/vcpkg_installed",
+        "VCPKG_TARGET_TRIPLET": "arm64-android",
+        "VCPKG_MANIFEST_FEATURES": "tests;imgui"
+      }
+    },
+    {
+      "name": "android-debug",
+      "displayName": "Android Debug",
+      "inherits": "android-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "android-debug-vcpkg",
+      "displayName": "Android Debug Vcpkg",
+      "inherits": "android-base-vcpkg",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "android-release",
+      "displayName": "Android Release",
+      "inherits": "android-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "android-release-vcpkg",
+      "displayName": "Android Release Vcpkg",
+      "inherits": "android-base-vcpkg",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     }
   ]
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,4 +22,8 @@ else() # GTest is being linked as vcpkg package
     find_package(GTest CONFIG REQUIRED)
     target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest GTest::gtest_main omath::omath)
 endif()
-gtest_discover_tests(${PROJECT_NAME})
+
+# Skip test discovery for Android builds - binaries cannot run on host
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+    gtest_discover_tests(${PROJECT_NAME})
+endif()


### PR DESCRIPTION
CMAKE_SYSTEM_VERSION set to 24 (Android 7.0) to resolve `stderr`, `stdout`, `__write_chk` symbols.
```cmake
# Skip test discovery for Android builds - binaries cannot run on host
if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
    gtest_discover_tests(${PROJECT_NAME})
endif()
```