### PR TITLE
Add iOS support

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -122,7 +122,47 @@ jobs:
         run: ./out/Release/unit_tests
 
   ##############################################################################
-  # 4)  FreeBSD  –  Clang / Ninja
+  # 4)  iOS  –  AppleClang / Xcode / arm64-ios
+  ##############################################################################
+  ios-build:
+    name: iOS (AppleClang) (arm64-ios)
+    runs-on: macOS-latest
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+    steps:
+      - name: Install CMake tooling
+        shell: bash
+        run: |
+          brew install cmake ninja
+
+      - name: Checkout repository (with sub-modules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up vcpkg
+        shell: bash
+        run: |
+          git clone https://github.com/microsoft/vcpkg "$VCPKG_ROOT"
+          cd "$VCPKG_ROOT"
+          ./bootstrap-vcpkg.sh
+
+      - name: Configure (cmake --preset)
+        shell: bash
+        run: |
+          cmake --preset ios-release-vcpkg \
+            -DVCPKG_INSTALL_OPTIONS="--allow-unsupported" \
+            -DOMATH_BUILD_TESTS=ON \
+            -DOMATH_BUILD_BENCHMARK=OFF \
+            -DVCPKG_MANIFEST_FEATURES="imgui;tests"
+
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build cmake-build/build/ios-release-vcpkg --config Release --target unit_tests omath
+
+  ##############################################################################
+  # 5)  FreeBSD  –  Clang / Ninja
   ##############################################################################
   freebsd-build-and-test:
     name: FreeBSD (Clang) (x64-freebsd)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -180,6 +180,38 @@
       }
     },
     {
+  "name": "ios-base",
+  "hidden": true,
+  "generator": "Ninja",
+  "binaryDir": "${sourceDir}/cmake-build/build/${presetName}",
+  "cacheVariables": {
+    "CMAKE_SYSTEM_NAME": "iOS",
+    "CMAKE_OSX_DEPLOYMENT_TARGET": "18.5",
+    "CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED": "NO",
+    "CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED": "NO"
+  },
+  "condition": {
+    "type": "equals",
+    "lhs": "${hostSystemName}",
+    "rhs": "Darwin"
+  }
+},
+{
+  "name": "ios-base-vcpkg",
+  "hidden": true,
+  "inherits": "ios-base",
+  "cacheVariables": {
+    "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+    "VCPKG_TARGET_TRIPLET": "arm64-ios",
+    "VCPKG_HOST_TRIPLET": "arm64-osx"
+  }
+},
+{
+  "name": "ios-release-vcpkg",
+  "displayName": "iOS Release (vcpkg)",
+  "inherits": "ios-base-vcpkg"
+},
+    {
       "name": "freebsd-base",
       "hidden": true,
       "generator": "Ninja",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,6 @@ else() # GTest is being linked as vcpkg package
 endif()
 
 # Skip test discovery for Android builds - binaries cannot run on host
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+if (NOT (CMAKE_SYSTEM_NAME STREQUAL "Android" OR CMAKE_SYSTEM_NAME STREQUAL "iOS"))
     gtest_discover_tests(${PROJECT_NAME})
 endif()


### PR DESCRIPTION
`CMAKE_OSX_DEPLOYMENT_TARGET` is 18.5 as vcpkg deps are built with that version, as specifying 16.3 should be enough but deps are being built with 18.5 anyway as CMakePreset does not affect to deps building process.