### PR TITLE
Run unit tests for WASM

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -506,6 +506,14 @@ jobs:
             cmake-build/build/${{ matrix.preset }}/**/*.log
             ${{ env.VCPKG_ROOT }}/buildtrees/**/*.log
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run WASM Unit Tests
+        run: node out/Release/unit_tests.js
+
   ##############################################################################
   # 8)  Windows MSYS2 MinGW  –  GCC / Ninja
   ##############################################################################

--- a/include/omath/linear_algebra/vector3.hpp
+++ b/include/omath/linear_algebra/vector3.hpp
@@ -233,10 +233,10 @@ namespace omath
             return Angle<float, 0.f, 180.f, AngleFlags::Clamped>::from_radians(std::acos(dot(other) / bottom));
         }
 
-        [[nodiscard]] bool is_perpendicular(const Vector3& other) const noexcept
+        [[nodiscard]] bool is_perpendicular(const Vector3& other, Type epsilon = static_cast<Type>(0.0001)) const noexcept
         {
             if (const auto angle = angle_between(other))
-                return angle->as_degrees() == static_cast<Type>(90);
+                return std::abs(angle->as_degrees() - static_cast<Type>(90)) <= epsilon;
 
             return false;
         }

--- a/tests/general/unit_test_vector3.cpp
+++ b/tests/general/unit_test_vector3.cpp
@@ -390,8 +390,10 @@ TEST_F(UnitTestVector3, AsTuple)
 // Test AsTuple method
 TEST_F(UnitTestVector3, AngleBeatween)
 {
-    EXPECT_EQ(Vector3(0.0f, 0.0f, 1.0f).angle_between({1, 0 ,0}).value().as_degrees(), 90.0f);
-    EXPECT_EQ(Vector3(0.0f, 0.0f, 1.0f).angle_between({0.0f, 0.0f, 1.0f}).value().as_degrees(), 0.0f);
+    EXPECT_NEAR(Vector3(0.0f, 0.0f, 1.0f).angle_between({1, 0, 0}).value().as_degrees(),
+                90.0f, 0.001f);
+    EXPECT_NEAR(Vector3(0.0f, 0.0f, 1.0f).angle_between({0.0f, 0.0f, 1.0f}).value().as_degrees(),
+                0.0f, 0.001f);
     EXPECT_FALSE(Vector3(0.0f, 0.0f, 0.0f).angle_between({0.0f, 0.0f, 1.0f}).has_value());
 }
 


### PR DESCRIPTION
Simplify strict checks as for wasm floating point is not really accurate.

```
[ RUN ] UnitTestVector3.AngleBeatween
/home/runner/work/omath/omath/tests/general/unit_test_vector3.cpp:393: Failure
Expected equality of these values:
Vector3(0.0f, 0.0f, 1.0f).angle_between({1, 0 ,0}).value().as_degrees()
Which is: 89.9999924
90.0f
Which is: 90

[ FAILED ] UnitTestVector3.AngleBeatween (1 ms)
```

```
DEBUG is_perpendicular: angle = 89.99999 degrees
/home/runner/work/omath/omath/tests/general/unit_test_vector3.cpp:402: Failure
Expected equality of these values:
Vector3(0.0f, 0.0f, 1.0f).is_perpendicular({1, 0 ,0})
Which is: false
true
DEBUG is_perpendicular: angle = 0 degrees
[ FAILED ] UnitTestVector3.IsPerpendicular (1 ms)
```