### PR TITLE
Add missing `find_dependency` calls.

### DIFF
--- a/cmake/omathConfig.cmake.in
+++ b/cmake/omathConfig.cmake.in
@@ -6,6 +6,17 @@ if (@OMATH_IMGUI_INTEGRATION@)
     find_dependency(imgui CONFIG)
 endif()
 
+if (@OMATH_ENABLE_LUA@)
+    find_dependency(Lua)
+endif()
+
+if (@OMATH_ENABLE_HOOKING@)
+    find_dependency(safetyhook CONFIG)
+    if (NOT WIN32 AND (UNIX AND NOT APPLE))
+        find_dependency(OpenGL)
+    endif()
+endif()
+
 # Load the targets for the omath library
 include("${CMAKE_CURRENT_LIST_DIR}/omathTargets.cmake")
 check_required_components(omath)


### PR DESCRIPTION
This was detected in reviewing https://github.com/microsoft/vcpkg/pull/52901/ by GPT 5.6 Sol.

(Also the file VERSION in this repo still claims 5.4.0 rather than 5.5.0 but I have not tried to fix that in this PR as I'm not sure what you want your next version to be)